### PR TITLE
remove empty inline tokens

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,8 +94,10 @@ module.exports = function attributes(md) {
       }
 
       // attributes for blocks
+      var lastInlineToken;
       if (hasCurly(tokens[i].content)) {
-        var content = last(inlineTokens).content;
+        lastInlineToken = last(inlineTokens);
+        var content = lastInlineToken.content;
         var curlyStart = content.lastIndexOf('{');
         var attrs = utils.getAttrs(content, curlyStart + 1, content.length - 1);
         // if list and `\n{#c}` -> apply to bullet list open:
@@ -126,7 +128,11 @@ module.exports = function attributes(md) {
           }
         } else {
           utils.addAttrs(attrs, correspondingBlock);
-          last(inlineTokens).content = removeCurly(content);
+          lastInlineToken.content = removeCurly(content);
+          if (lastInlineToken.content === '') {
+            // remove empty inline token
+            inlineTokens.pop();
+          }
           tokens[i].content = removeCurly(tokens[i].content);
         }
       }


### PR DESCRIPTION
```md
![](img.png) {.asdf}
```

will give

```js
Token {
  type: 'inline',
  tag: '',
  attrs: null,
  map: [ 0, 1 ],
  nesting: 0,
  level: 1,
  children:
   [ Token {
       type: 'image',
       tag: 'img',
       attrs: [Object],
       map: null,
       nesting: 0,
       level: 0,
       children: [],
       content: '',
       markup: '',
       info: '',
       meta: null,
       block: false,
       hidden: false },
     Token {
       type: 'text',
       tag: '',
       attrs: null,
       map: null,
       nesting: 0,
       level: 0,
       children: null,
       content: '',
       markup: '',
       info: '',
       meta: null,
       block: false,
       hidden: false } ],
  content: '![](img.png)',
  markup: '',
  info: '',
  meta: null,
  block: true,
  hidden: false }
```

This removes last child with empty text. Fixes arve0/markdown-it-implicit-figures#13.