### PR TITLE
Implicit figures

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -7,6 +7,4 @@ md.use(markdownItAttrs);
 var src = '# header {.style-me}\n';
 src += 'paragraph {data-toggle=modal}';
 
-var res = md.render(src);
-
-console.log(res);  // eslint-disable-line
+md.render(src);

--- a/index.js
+++ b/index.js
@@ -139,7 +139,7 @@ module.exports = function attributes(md) {
 
     }
   }
-  md.core.ruler.before('replacements', 'curly_attributes', curlyAttrs);
+  md.core.ruler.before('linkify', 'curly_attributes', curlyAttrs);
 };
 
 /**

--- a/test.js
+++ b/test.js
@@ -164,7 +164,8 @@ describe('markdown-it-attrs', () => {
   it('should work with typography enabled', () => {
     src = 'text {key="val with spaces"}';
     expected = '<p key="val with spaces">text</p>\n';
-    assert.equal(md.render(src), expected);
+    var res = md.set({ typographer: true }).render(src);
+    assert.equal(res, expected);
   });
 
   it('should support code blocks', () => {


### PR DESCRIPTION
Should work with [implicit-figures](/arve0/markdown-it-implicit-figures/), fixes https://github.com/arve0/markdown-it-implicit-figures/issues/18.

Usage:

```js
md
  .use(attrs)  // must load attrs plugin first
  .use(implicitFigures);
```