### PR TITLE
add support for tables, fixes #39

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,9 +7,8 @@ module.exports = function attributes(md) {
 
   function curlyAttrs(state){
     var tokens = state.tokens;
-    var l = tokens.length;
 
-    for (var i = 0; i < l; ++i) {
+    for (var i = 0; i < tokens.length; ++i) {
       let token = tokens[i];
       let pattern;
       if (token.block) {

--- a/patterns.js
+++ b/patterns.js
@@ -123,6 +123,46 @@ module.exports = [
         utils.addAttrs(inlineAttrs, attrToken);
       }
     }
+  }, {
+    /**
+     * | h1 |
+     * | -- |
+     * | c1 |
+     * {.c}
+     */
+    name: 'tables',
+    type: 'block',
+    tests: [
+      {
+        // let this token be i, such that for loop continues at
+        // next token after tokens.splice
+        shift: 0,
+        type: 'table_close'
+      }, {
+        shift: 1,
+        type: 'paragraph_open'
+      }, {
+        shift: 2,
+        type: 'inline',
+        children: [
+          (arr) => arr && arr.length === 1,
+          (arr) => utils.hasCurlyInStart(arr[0].content)
+        ]
+      }
+    ],
+    transform: (tokens, i) => {
+      let token = tokens[i + 2];
+      var tableOpen = utils.matchingOpeningToken(tokens, i);
+      if (!tableOpen) { return; }
+      var inlineAttrs = utils.getAttrs(token.content, 1, token.content.length - 1);
+      if (inlineAttrs.length !== 0) {
+        // remove <p>{.c}</p>
+        tokens.splice(i + 1, 3);
+        // add attributes
+        utils.addAttrs(inlineAttrs, tableOpen);
+      }
+
+    }
   }
 ];
 

--- a/test.js
+++ b/test.js
@@ -185,5 +185,27 @@ describe('markdown-it-attrs', () => {
     expected = '<blockquote class="c">\n<p>quote</p>\n</blockquote>\n';
     assert.equal(md.render(src), expected);
   });
+
+  it('should support tables', () => {
+    src = '| h1 | h2 |\n';
+    src += '| -- | -- |\n';
+    src += '| c1 | c1 |\n';
+    src += '{.c}';
+    expected = '<table class="c">\n';
+    expected += '<thead>\n';
+    expected += '<tr>\n';
+    expected += '<th>h1</th>\n';
+    expected += '<th>h2</th>\n';
+    expected += '</tr>\n';
+    expected += '</thead>\n';
+    expected += '<tbody>\n';
+    expected += '<tr>\n';
+    expected += '<td>c1</td>\n';
+    expected += '<td>c1</td>\n';
+    expected += '</tr>\n';
+    expected += '</tbody>\n';
+    expected += '</table>\n';
+    assert.equal(md.render(src), expected);
+  });
 });
 


### PR DESCRIPTION
syntax:

```md
| header1 | header2 |
| ------- | ------- |
| cell1   | cell2   |
{.cls attribute=1 #i}
```

gives

```html
<table class="cls" attribute="1" id="i">
<thead>
<tr>
<th>header1</th>
<th>header2</th>
</tr>
</thead>
<tbody>
<tr>
<td>cell1</td>
<td>cell2</td>
</tr>
</tbody>
</table>
```