### PR TITLE
Add CSS Modules support

### DIFF
--- a/test.js
+++ b/test.js
@@ -6,9 +6,9 @@ const markdownItAttrs = require('./');
 const utils = require('./utils.js');
 
 describe('markdown-it-attrs.utils', () => {
-  it('should parse {.class #id key=val}', () => {
-    let src = '{.red #head key=val}';
-    let expected = [['class', 'red'], ['id', 'head'], ['key', 'val']];
+  it('should parse {.class ..css-module #id key=val}', () => {
+    let src = '{.red ..mod #head key=val}';
+    let expected = [['class', 'red'], ['css-module', 'mod'], ['id', 'head'], ['key', 'val']];
     let res = utils.getAttrs(src, 0);
     assert.deepEqual(res, expected);
   });
@@ -38,15 +38,21 @@ describe('markdown-it-attrs', () => {
     assert.equal(md.render(src), expected);
   });
 
+  it('should add css-modules with {..css-module} double dot notation', () => {
+    src = 'some text {..green}';
+    expected = '<p css-module="green">some text</p>\n';
+    assert.equal(md.render(src), expected);
+  });
+
   it('should add identifiers with {#id} hashtag notation', () => {
     src = 'some text {#section2}';
     expected = '<p id="section2">some text</p>\n';
     assert.equal(md.render(src), expected);
   });
 
-  it('should support classes, identifiers and attributes in same {}', () => {
-    src = 'some text {attr=lorem .class #id}';
-    expected = '<p attr="lorem" class="class" id="id">some text</p>\n';
+  it('should support classes, css-modules, identifiers and attributes in same {}', () => {
+    src = 'some text {attr=lorem .class ..css-module #id}';
+    expected = '<p attr="lorem" class="class" css-module="css-module" id="id">some text</p>\n';
     assert.equal(md.render(src), expected);
   });
 
@@ -59,6 +65,12 @@ describe('markdown-it-attrs', () => {
   it('should add classes in same class attribute {.c1 .c2} -> class="c1 c2"', () => {
     src = 'some text {.c1 .c2}';
     expected = '<p class="c1 c2">some text</p>\n';
+    assert.equal(md.render(src), expected);
+  });
+
+  it('should add nested css-modules {..c1.c2} -> css-module="c1.c2"', () => {
+    src = 'some text {..c1.c2}';
+    expected = '<p css-module="c1.c2">some text</p>\n';
     assert.equal(md.render(src), expected);
   });
 

--- a/test.js
+++ b/test.js
@@ -68,6 +68,12 @@ describe('markdown-it-attrs', () => {
     assert.equal(md.render(src), expected);
   });
 
+  it('should add css-modules in same css-modules attribute {..c1 ..c2} -> css-module="c1 c2"', () => {
+    src = 'some text {..c1 ..c2}';
+    expected = '<p css-module="c1 c2">some text</p>\n';
+    assert.equal(md.render(src), expected);
+  });
+
   it('should add nested css-modules {..c1.c2} -> css-module="c1.c2"', () => {
     src = 'some text {..c1.c2}';
     expected = '<p css-module="c1.c2">some text</p>\n';

--- a/utils.js
+++ b/utils.js
@@ -105,6 +105,8 @@ exports.addAttrs = function (attrs, token) {
     let key = attrs[j][0];
     if (key === 'class') {
       token.attrJoin('class', attrs[j][1]);
+    } else if (key === 'css-module') {
+      token.attrJoin('css-module', attrs[j][1]);
     } else {
       token.attrPush(attrs[j]);
     }

--- a/utils.js
+++ b/utils.js
@@ -37,11 +37,16 @@ exports.getAttrs = function (str, start, end) {
       continue;
     }
 
-    // {.class}
-    if (char_ === classChar && key === '') {
-      key = 'class';
-      parsingKey = false;
-      continue;
+    // {.class} {..css-module}
+    if (char_ === classChar) {
+      if (key === '') {
+        key = 'class';
+        parsingKey = false;
+        continue;
+      } else if (key === 'class') {
+        key = 'css-module';
+        continue;
+      }
     }
 
     // {#id}


### PR DESCRIPTION
```
text {..green} -> <p css-module="green">text</p>
```

This feature can work with [posthtml-css-modules](https://github.com/posthtml/posthtml-css-modules) then we can use CSS Modules enabled markdown.