### PR TITLE
fix ~ checkout eol=LF always

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text=auto
+* text=auto eol=lf


### PR DESCRIPTION
* forces LFs for checked out text files (regardless of local git config)

I keep butting up against this on a Windows machine that I have configured as CRLF for default checkouts. Since testing (specifically `eslint`) gets mad about it, I'm proposing this change to avoid the issue, regardless of local config.


