### PR TITLE
do not match for short curlies when repeating: {1}{2}

### DIFF
--- a/test.js
+++ b/test.js
@@ -267,5 +267,11 @@ describe('markdown-it-attrs', () => {
     expected = '<p>bla <code class="c">click()</code> blah <code class="cpp">release()</code></p>\n';
     assert.equal(md.render(src), expected);
   });
+
+  it('should not remove {} curlies with length < 4', () => {
+    src = 'do not remove the curlies {1}{2}';
+    expected = '<p>do not remove the curlies {1}{2}</p>\n';
+    assert.equal(md.render(src), expected);
+  });
 });
 

--- a/utils.js
+++ b/utils.js
@@ -157,7 +157,7 @@ exports.hasCurly = function (where) {
     case 'end':
       // last char should be }
       end = str.charAt(str.length - 1) === '}';
-      start = end && str.indexOf('{');
+      start = end && str.lastIndexOf('{');
       return end && (start + 3) < str.length;
 
     case 'only':


### PR DESCRIPTION
fixes issue #58