### PR TITLE
Updated gree to green on css-module attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Use the css-module green on this paragraph. {..green}
 
 Output:
 ```html
-<p css-module="gree">Use the css-module green on this paragraph.</p>
+<p css-module="green">Use the css-module green on this paragraph.</p>
 ```
 
 


### PR DESCRIPTION
This PR is intended to fix a small typo on the README.

 I am assuming that `css-module="gree"` is a typo and should be `css-module="green"`.