### PR TITLE
update peer / dev dependencies for markdown-it@10.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1958,9 +1958,9 @@
       }
     },
     "entities": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
+      "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
       "dev": true
     },
     "error-ex": {
@@ -3221,13 +3221,13 @@
       }
     },
     "markdown-it": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-9.0.1.tgz",
-      "integrity": "sha512-XC9dMBHg28Xi7y5dPuLjM61upIGPJG8AiHNHYqIaXER2KNnn7eKnM5/sF0ImNnyoV224Ogn9b1Pck8VH4k0bxw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
+      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
-        "entities": "~1.1.1",
+        "entities": "~2.0.0",
         "linkify-it": "^2.0.0",
         "mdurl": "^1.0.1",
         "uc.micro": "^1.0.5"

--- a/package.json
+++ b/package.json
@@ -43,13 +43,13 @@
     "browserify": "^16.2.3",
     "coveralls": "^3.0.3",
     "eslint": "^5.16.0",
-    "markdown-it": "^9.0.0",
+    "markdown-it": "^10.0.0",
     "markdown-it-implicit-figures": "^0.9.0",
     "mocha": "*",
     "nyc": "^14.1.1"
   },
   "peerDependencies": {
-    "markdown-it": "^9.0.0"
+    "markdown-it": ">= 9.0.0 < 11.0.0"
   },
   "tonicExampleFilename": "demo.js"
 }


### PR DESCRIPTION
I don't completely understand the technical details of why markdown-it bumped to 10.0.0—check [its changelog](https://github.com/markdown-it/markdown-it/blob/10.0.0/CHANGELOG.md#1000---2019-09-11) for details—but they do say that most plugins will just work, and this seems to work, so perhaps the peer dependencies can be updated?

Needed for a project that uses vsce to create a Visual Studio Code plugin; the packager fails if there are peer dependency warnings.

I have tested using:

```
rm -Rf node_modules
npm install
npm test
```

`npm ls | grep markdown-it` shows a version of 10.0.0.