### PR TITLE
Update markdown-it to v11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2023,9 +2023,9 @@
       }
     },
     "entities": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
-      "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.2.tgz",
+      "integrity": "sha512-dmD3AvJQBUjKpcNkoqr+x+IF0SdRtPz9Vk0uTy4yWqga9ibB6s4v++QFWNohjiUGoMlF552ZvNyXDxz5iW0qmw==",
       "dev": true
     },
     "error-ex": {
@@ -3199,9 +3199,9 @@
       }
     },
     "linkify-it": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
-      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.2.tgz",
+      "integrity": "sha512-gDBO4aHNZS6coiZCKVhSNh43F9ioIL4JwRjLZPkoLIY4yZFwg264Y5lu2x6rb1Js42Gh6Yqm2f6L2AJcnkzinQ==",
       "dev": true,
       "requires": {
         "uc.micro": "^1.0.1"
@@ -3309,14 +3309,14 @@
       }
     },
     "markdown-it": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
-      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-11.0.0.tgz",
+      "integrity": "sha512-+CvOnmbSubmQFSA9dKz1BRiaSMV7rhexl3sngKqFyXSagoA3fBdJQ8oZWtRy2knXdpDXaBw44euz37DeJQ9asg==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "entities": "~2.0.0",
-        "linkify-it": "^2.0.0",
+        "linkify-it": "^3.0.1",
         "mdurl": "^1.0.1",
         "uc.micro": "^1.0.5"
       }

--- a/package.json
+++ b/package.json
@@ -43,13 +43,13 @@
     "browserify": "^16.2.3",
     "coveralls": "^3.0.3",
     "eslint": "^5.16.0",
-    "markdown-it": "^10.0.0",
+    "markdown-it": "^11.0.0",
     "markdown-it-implicit-figures": "^0.9.0",
     "mocha": "^7.1.1",
     "nyc": "^14.1.1"
   },
   "peerDependencies": {
-    "markdown-it": ">= 9.0.0 < 11.0.0"
+    "markdown-it": ">= 9.0.0 < 12.0.0"
   },
   "tonicExampleFilename": "demo.js"
 }


### PR DESCRIPTION
Markdown-it v11 was just [released](https://github.com/markdown-it/markdown-it/blob/master/CHANGELOG.md#1100---2020-05-20). This PR updates the dev dependency to v11 and the peer dependency range to accept v11. All tests passed.