### PR TITLE
Update markdown-it to v12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2023,9 +2023,9 @@
       }
     },
     "entities": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.2.tgz",
-      "integrity": "sha512-dmD3AvJQBUjKpcNkoqr+x+IF0SdRtPz9Vk0uTy4yWqga9ibB6s4v++QFWNohjiUGoMlF552ZvNyXDxz5iW0qmw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+      "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
       "dev": true
     },
     "error-ex": {
@@ -3309,16 +3309,24 @@
       }
     },
     "markdown-it": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-11.0.0.tgz",
-      "integrity": "sha512-+CvOnmbSubmQFSA9dKz1BRiaSMV7rhexl3sngKqFyXSagoA3fBdJQ8oZWtRy2knXdpDXaBw44euz37DeJQ9asg==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.0.2.tgz",
+      "integrity": "sha512-4Lkvjbv2kK+moL9TbeV+6/NHx+1Q+R/NIdUlFlkqkkzUcTod4uiyTJRiBidKR9qXSdkNFkgv+AELY8KN9vSgVA==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
+        "argparse": "^2.0.1",
         "entities": "~2.0.0",
         "linkify-it": "^3.0.1",
         "mdurl": "^1.0.1",
         "uc.micro": "^1.0.5"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        }
       }
     },
     "markdown-it-implicit-figures": {

--- a/package.json
+++ b/package.json
@@ -43,13 +43,13 @@
     "browserify": "^16.2.3",
     "coveralls": "^3.0.3",
     "eslint": "^5.16.0",
-    "markdown-it": "^11.0.0",
+    "markdown-it": "^12.0.2",
     "markdown-it-implicit-figures": "^0.9.0",
     "mocha": "^7.1.1",
     "nyc": "^14.1.1"
   },
   "peerDependencies": {
-    "markdown-it": ">= 9.0.0 < 12.0.0"
+    "markdown-it": ">= 9.0.0 < 13.0.0"
   },
   "tonicExampleFilename": "demo.js"
 }

--- a/test.js
+++ b/test.js
@@ -272,6 +272,7 @@ function describeTestsWithOptions(options, postText) {
       src = '| h1 | h2 |\n';
       src += '| -- | -- |\n';
       src += '| c1 | c1 |\n';
+      src += '\n';
       src += '{.c}';
       expected = '<table class="c">\n';
       expected += '<thead>\n';


### PR DESCRIPTION
Also fixes #113 by adding a blank line after the table in a test. The new behavior in markdown-it v12 is correct according to [GitHub Flavored Markdown Spec](https://github.github.com/gfm/#example-202). The blank line works the same way in markdown-it versions 9 through 11 too.