### PR TITLE
Add attribute list definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,23 @@ Output:
 <p>paragraph with <span class="red">a style me span</span></p>
 ```
 
+Attribute definition lists supports inheritance based on [kramdown Syntax](https://kramdown.gettalong.org/syntax.html#attribute-list-definitions). `id` attributes are not included.
+
+They require to be preceded and followed by an empty line and other content inside these blocks will not be parsed. `id` attributes are not included:
+
+```md
+{ald: #someid .someclass attr="allowed"}
+{anotherald: someald #anotherid .anotherclass anotherattr="allowed"}
+
+another text
+{anotherald}
+```
+
+Output:
+```html
+<p class="someclass anotherclass" attr="allowed" id="anotherid" anotherattr="allowed">another text</p>
+```
+
 ## Install
 
 ```

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const patternsConfig = require('./patterns.js');
+const utils = require('./utils.js');
 
 const defaultOptions = {
   leftDelimiter: '{',
@@ -16,6 +17,8 @@ module.exports = function attributes(md, options_) {
 
   function curlyAttrs(state) {
     let tokens = state.tokens;
+    // clean ALDs for each document
+    utils.attributeListDefintions.clear();
 
     for (let i = 0; i < tokens.length; i++) {
       for (let p = 0; p < patterns.length; p++) {

--- a/patterns.js
+++ b/patterns.js
@@ -12,7 +12,45 @@ module.exports = options => {
                           + '[^' + utils.escapeRegExp(options.rightDelimiter) + ']');
 
   return ([
+    /**
+     * {ald1 #id1 .class1 attr1="value1"}
+     * {ald2 #id2 .class2 attr2="value2"}
+     * ...
+     * 
+    */
     {
+      name: 'attribute list definitions',
+      tests: [
+        { 
+          shift: 0,
+          block: true,
+          content: utils.hasDelimiters('only', options)
+        }
+      ],
+      transform: (tokens, i) => {
+        const token = tokens[i];
+
+        const hasDelimiters = utils.hasDelimiters('only', options);
+        let hasAlds = false;
+
+        for (const child of token.children) {
+          if (child.type === 'text' && hasDelimiters(child.content)) {
+            const childStart =
+              child.content.lastIndexOf(options.leftDelimiter);
+            const attrs = utils.getAttrs(child.content, childStart, options);
+            if (attrs.length && attrs[0][0] === 'attributeListDefinition') {
+              utils.attributeListDefintions.set(attrs[0][1], attrs.slice(1));
+              hasAlds = true;
+            }
+          }
+        }
+
+        if (hasAlds) {
+          // remove surrounding paragraph
+          tokens.splice(i - 1, 3);
+        }
+      }
+    }, {
       /**
        * ```python {.cls}
        * for i in range(10):

--- a/test.js
+++ b/test.js
@@ -381,6 +381,31 @@ function describeTestsWithOptions(options, postText) {
       expected = '<p class="someclass" attr="allowed">text</p>\n';
       assert.equal(md.render(replaceDelimiters(src, options)), expected);
     });
+
+    it('should support attribute list definitions', () => {
+      src = '{someald: #someid .someclass attr="allowed"}\n\n';
+      src += 'some text\n';
+      src += '{someald}';
+      expected = '<p id="someid" class="someclass" attr="allowed">some text</p>\n';
+      assert.equal(md.render(replaceDelimiters(src, options)), expected);
+    });
+
+    it('should support single attribute list definitions and references', () => {
+      src = '{someald: #someid .someclass attr="allowed"}\n\n';
+      src += 'some text\n';
+      src += '{someald}';
+      expected = '<p id="someid" class="someclass" attr="allowed">some text</p>\n';
+      assert.equal(md.render(replaceDelimiters(src, options)), expected);
+    });
+
+    it('should support multiple attribute list definitions with inheritance and references', () => {
+      src = '{someald: #someid .someclass attr="allowed"}\n';
+      src += '{anotherald: someald #anotherid .anotherclass anotherattr="allowed"}\n\n';
+      src += 'another text\n';
+      src += '{anotherald}';
+      expected = '<p class="someclass anotherclass" attr="allowed" id="anotherid" anotherattr="allowed">another text</p>\n';
+      assert.equal(md.render(replaceDelimiters(src, options)), expected);
+    });
   });
 }
 


### PR DESCRIPTION
This is a basic attribute list definitions implementation. It can be done in a more orthodox way and cover more use cases, but that would require substantial refactoring.
