### PR TITLE
hr elements does not accept multiple classes

### DIFF
--- a/patterns.js
+++ b/patterns.js
@@ -296,7 +296,8 @@ module.exports = options => {
         token.nesting = 0;
         let content = tokens[i + 1].content;
         let start = content.lastIndexOf(options.leftDelimiter);
-        token.attrs = utils.getAttrs(content, start, options);
+        let attrs = utils.getAttrs(content, start, options);
+        utils.addAttrs(attrs, token);
         token.markup = content;
         tokens.splice(i + 1, 2);
       }

--- a/test.js
+++ b/test.js
@@ -389,6 +389,12 @@ function describeTestsWithOptions(options, postText) {
       expected = '<p class="someclass" attr="allowed">text</p>\n';
       assert.equal(md.render(replaceDelimiters(src, options)), expected);
     });
+
+    it(replaceDelimiters('should support multiple classes for <hr>', options), () => {
+      src = '--- {.a .b}';
+      expected = '<hr class="a b">\n';
+      assert.equal(md.render(replaceDelimiters(src, options)), expected);
+    });
   });
 }
 


### PR DESCRIPTION
Hi @arve0, 
after looking at the code more carefully, the issue discussed in https://github.com/arve0/markdown-it-attrs/issues/131 turns out to be in `markdown-it-attrs`. It's a very minor bug that only affects hr elements. I am working on a project that uses `markdown-it-attrs` (Thank you 😃), hence putting up this PR to fix the issue at the root.

---
This PR fixes https://github.com/arve0/markdown-it-attrs/issues/131

Like other elements, hr elements should also allow multiple
classes to be added. Currently, hr elements have a direct
assignment of attributes in patterns.js. Thus, multiple
class attributes are not combined into one.

By using the `utils.addAttrs` method, the attribute values
will be merged correctly.

This bug fix helps with attributes on hr elements.
Example:`--- {.a .b}`
Before:`<hr class='a' class='b'>`
After: `<hr class='a b'>`

PS:
I am not sure if I should update browser.js, please feel free to let me know if it needs to be done:)