### PR TITLE
Update hasDelimiters function documentation

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -133,17 +133,16 @@ exports.addAttrs = function (attrs, token) {
  * Does string have properly formatted curly?
  *
  * start: '{.a} asdf'
- * middle: 'a{.b}c'
  * end: 'asdf {.a}'
  * only: '{.a}'
  *
- * @param {string} where to expect {} curly. start, middle, end or only.
+ * @param {string} where to expect {} curly. start, end or only.
  * @return {function(string)} Function which testes if string has curly.
  */
 exports.hasDelimiters = function (where, options) {
 
   if (!where) {
-    throw new Error('Parameter `where` not passed. Should be "start", "middle", "end" or "only".');
+    throw new Error('Parameter `where` not passed. Should be "start", "end" or "only".');
   }
 
   /**


### PR DESCRIPTION
Update the documentation of the `hasDelimiters` function in `utils.js`

The original comment mentions "middle" as a possible `where` value.
However, all invocations of `hasDelimiters` in `patterns.js` do not
pass in "middle". The function itself has since removed the "middle" case
in [a previous commit](https://github.com/arve0/markdown-it-attrs/commit/17c717d6886e0e9beab5f39f6658c3d24161bbb6#diff-fda8f0e13abe3d5c5685ad895fa528dd6067c41b66b6ebc6d1de71ca9a704d8dL159-L164).

Let's update the documentation to remove the mention of "middle" to match 
current implementation.

The function is still working as expected as an inline case like
`paragraph **bold**{.red} asdf`  appears to now be handled 
correctly with `where=end`. Hence, this PR is purely a documentation update.