### PR TITLE
fix: empty quoted attr key eats the next attr

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -54,7 +54,7 @@ exports.getAttrs = function (str, start, options) {
     }
 
     // {value="inside quotes"}
-    if (char_ === '"' && value === '') {
+    if (char_ === '"' && value === '' && !valueInsideQuotes) {
       valueInsideQuotes = true;
       continue;
     }


### PR DESCRIPTION
Markdown with empty quoted strings for some attributes:
`![](https://example.com/image.jpg "title"){ class="" height="100" width="" }`

Will generate this HTML:
`<img src="https://example.com/image.jpg" alt="" title="title" class=" height=100&quot;" width=" ">`

Notice that `class` has eaten the `height` attribute and now contains ` height=100&quot;`. The `width` contains a space instead of nothing.