### PR TITLE
Fix attribute adding to avoid duplicates

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -123,7 +123,7 @@ exports.addAttrs = function (attrs, token) {
     } else if (key === 'css-module') {
       token.attrJoin('css-module', attrs[j][1]);
     } else {
-      token.attrPush(attrs[j]);
+      token.attrSet(key, attrs[j][1]);
     }
   }
   return token;


### PR DESCRIPTION
Right now, the plugin adds attributes to tokens in a way that causes duplicates if those attributes already exist. This pull request fixes the problem.

For example, suppose someone wants to use this plugin to add the `alt` attribute to an image:

```markdown
![An image of a bird](bird.jpg){alt="A green bird sitting on a fence"}
```

`markdown-it` already adds the `alt` attribute to Markdown image tokens. (For whatever reason, this attribute is empty.) When `markdown-it-attrs` adds the `alt` attribute because of the curly braces, it will *duplicate* the attribute. The attributes of the above token are:

```js
[
    ["alt", ""],
    ["src", "bird.jpg"],
    ["alt", "A green bird sitting on a fence"]
]
```

Due to the way that `markdown-it` provides attributes when using `token.attrGet`, only the first instance of any duplicated attribute will be accessible. In other words, it's as if the plugin has done nothing at all.

This pull request makes a single line change—from `token.attrPush` to `token.attrSet`—to fix the issue of duplicate attributes. The latter avoids adding duplicates and instead updates attributes that already exist. See [the docs](https://markdown-it.github.io/markdown-it/#Token.attrSet).