### PR TITLE
feat: add ability to filter attribute values

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,8 @@ const patternsConfig = require('./patterns.js');
 const defaultOptions = {
   leftDelimiter: '{',
   rightDelimiter: '}',
-  allowedAttributes: []
+  allowedAttributes: [],
+  allowedAttributeValues: []
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const patternsConfig = require('./patterns.js');
  * @property {!string} leftDelimiter left delimiter, default is `{`(left curly bracket)
  * @property {!string} rightDelimiter right delimiter, default is `}`(right curly bracket)
  * @property {AllowedAttribute[]} allowedAttributes empty means no limit
+ * @property {AllowedAttribute[]} allowedAttributeValues empty means no limit
  *
  * @typedef {string|RegExp} AllowedAttribute rule of allowed attribute
  *

--- a/test.js
+++ b/test.js
@@ -43,6 +43,14 @@ function describeTestsWithOptions(options, postText) {
       assert.deepEqual(res, expected);
     });
 
+    it(replaceDelimiters('should omit values {.class ..css-module #id key=val .class.with.dot}', options), () => {
+      const src = '{.good-class .keep-me .ignore-class .good.class.with.dot .ignore.class.with.dot ..good ..ignore #good #ignore-id key=key-to-ignore key=good-key}';
+      const expected = [['class', 'good-class'], ['class', 'keep-me'], ['class', 'good.class.with.dot'], ['css-module', 'good'], ['id', 'good'], ['key', 'good-key']];
+      const newOptions = Object.assign({}, options, { allowedAttributeValues: [/^good/, 'keep-me'] });
+      const res = utils.getAttrs(replaceDelimiters(src, options), 0, newOptions);
+      assert.deepEqual(res, expected);
+    });
+
     it(replaceDelimiters('should parse attributes with = {attr=/id=1}', options), () => {
       const src = '{link=/some/page/in/app/id=1}';
       const expected = [['link', '/some/page/in/app/id=1']];

--- a/utils.js
+++ b/utils.js
@@ -97,12 +97,25 @@ exports.getAttrs = function (str, start, options) {
     value += char_;
   }
 
-  if (options.allowedAttributes && options.allowedAttributes.length) {
-    const allowedAttributes = options.allowedAttributes;
+  const needsFilterAttributes = options.allowedAttributes && options.allowedAttributes.length;
+  const needsFilterAttributeValues = options.allowedAttributeValues && options.allowedAttributeValues.length;
 
+  if (needsFilterAttributes || needsFilterAttributeValues) {
+    const allowedAttributes = options.allowedAttributes;
+    const allowedAttributeValues = options.allowedAttributeValues;
     return attrs.filter(function (attrPair) {
       const attr = attrPair[0];
-
+      const attrValue = attrPair[1];
+      let attrPassed = !needsFilterAttributes;
+      let attrValuePassed = !needsFilterAttributeValues;
+      /**
+       * @param {AllowedAttribute} allowedAttributeValue
+       */
+      function isAllowedAttributeValue (allowedAttributeValue) {
+        return (attrValue === allowedAttributeValue
+          || (allowedAttributeValue instanceof RegExp && allowedAttributeValue.test(attrValue))
+        );
+      }
       /**
        * @param {AllowedAttribute} allowedAttribute
        */
@@ -111,13 +124,16 @@ exports.getAttrs = function (str, start, options) {
           || (allowedAttribute instanceof RegExp && allowedAttribute.test(attr))
         );
       }
-
-      return allowedAttributes.some(isAllowedAttribute);
+      if (needsFilterAttributes) {
+        attrPassed = allowedAttributes.some(isAllowedAttribute);
+      }
+      if (needsFilterAttributeValues) {
+        attrValuePassed = allowedAttributeValues.some(isAllowedAttributeValue);
+      }
+      return attrPassed && attrValuePassed;
     });
-
   }
   return attrs;
-
 };
 
 /**


### PR DESCRIPTION
In the app I'm working on, we allow styling markdown via the use of classes, but we want to limit which classes can be used so customers can't apply styles to their markdown that we don't allow. Looks like there was a question about something similar to this feature here https://github.com/arve0/markdown-it-attrs/issues/112. This PR will not affect current behavior, but it adds a new option to compliment `allowedAttributes` called `allowedAttributeValues`. This follows the same pattern as `allowedAttributes` but will only look at the values instead of the keys.