### PR TITLE
fix: only install pre-fence renderer when default; add opt-out

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,7 @@ declare namespace markdownItAttrs {
     rightDelimiter?: string;
     allowedAttributes?: AllowedAttribute[];
     allowedAttributeValues?: AllowedAttribute[];
+    fenceAttrsOnPre?: boolean;
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -103,6 +103,33 @@ module.exports = function attributes(md, options_) {
   }
 
   md.core.ruler.before('linkify', 'curly_attributes', curlyAttrs);
+
+  // Always install a fence renderer so that markdown-it-attrs attributes go
+  // on <pre> (the outer element) rather than <code> (the inner element).
+  // This is a breaking change vs the default markdown-it behaviour.
+  //
+  // If you need a custom fence renderer (e.g. a syntax highlighter), set
+  // md.renderer.rules.fence AFTER calling md.use(attrs) so your renderer
+  // takes precedence over this one.
+  const originalFence = md.renderer.rules.fence;
+  md.renderer.rules.fence = function (tokens, idx, mdOptions, env, slf) {
+    const token = tokens[idx];
+    const savedAttrs = token.attrs ? token.attrs.slice() : null;
+
+    // Temporarily remove user attrs so the built-in renderer does not place
+    // them on <code>.
+    token.attrs = null;
+    const result = originalFence(tokens, idx, mdOptions, env, slf);
+    token.attrs = savedAttrs;
+
+    if (!savedAttrs || savedAttrs.length === 0) {
+      return result;
+    }
+
+    // Inject user attrs into the opening <pre> tag.
+    const attrsStr = slf.renderAttrs(token);
+    return result.replace(/^<pre([ >])/, (_, ch) => `<pre${attrsStr}${ch}`);
+  };
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const createMarkdownIt = require('markdown-it');
 const patternsConfig = require('./patterns.js');
 
 /**
@@ -16,6 +17,7 @@ const patternsConfig = require('./patterns.js');
  * @property {!string} rightDelimiter right delimiter, default is `}`(right curly bracket)
  * @property {AllowedAttribute[]} allowedAttributes empty means no limit
  * @property {AllowedAttribute[]} allowedAttributeValues empty means no limit
+ * @property {boolean} fenceAttrsOnPre set fenced-code attrs on <pre>, default true
  *
  * @typedef {string|RegExp} AllowedAttribute rule of allowed attribute
  *
@@ -57,7 +59,8 @@ const defaultOptions = {
   leftDelimiter: '{',
   rightDelimiter: '}',
   allowedAttributes: [],
-  allowedAttributeValues: []
+  allowedAttributeValues: [],
+  fenceAttrsOnPre: true
 };
 
 /**
@@ -104,32 +107,32 @@ module.exports = function attributes(md, options_) {
 
   md.core.ruler.before('linkify', 'curly_attributes', curlyAttrs);
 
-  // Always install a fence renderer so that markdown-it-attrs attributes go
-  // on <pre> (the outer element) rather than <code> (the inner element).
-  // This is a breaking change vs the default markdown-it behaviour.
-  //
-  // If you need a custom fence renderer (e.g. a syntax highlighter), set
-  // md.renderer.rules.fence AFTER calling md.use(attrs) so your renderer
-  // takes precedence over this one.
-  const originalFence = md.renderer.rules.fence;
-  md.renderer.rules.fence = function (tokens, idx, mdOptions, env, slf) {
-    const token = tokens[idx];
-    const savedAttrs = token.attrs ? token.attrs.slice() : null;
+  // Install a fence renderer to place attrs on <pre> instead of <code>.
+  // Do this only when enabled and no custom fence renderer is already present.
+  const defaultFence = createMarkdownIt().renderer.rules.fence;
+  const currentFence = md.renderer.rules.fence;
+  const hasCustomFence = typeof currentFence === 'function' && currentFence !== defaultFence;
 
-    // Temporarily remove user attrs so the built-in renderer does not place
-    // them on <code>.
-    token.attrs = null;
-    const result = originalFence(tokens, idx, mdOptions, env, slf);
-    token.attrs = savedAttrs;
+  if (options.fenceAttrsOnPre && !hasCustomFence && typeof currentFence === 'function') {
+    md.renderer.rules.fence = function (tokens, idx, mdOptions, env, slf) {
+      const token = tokens[idx];
+      const savedAttrs = token.attrs ? token.attrs.slice() : null;
 
-    if (!savedAttrs || savedAttrs.length === 0) {
-      return result;
-    }
+      // Temporarily remove user attrs so the built-in renderer does not place
+      // them on <code>.
+      token.attrs = null;
+      const result = currentFence(tokens, idx, mdOptions, env, slf);
+      token.attrs = savedAttrs;
 
-    // Inject user attrs into the opening <pre> tag.
-    const attrsStr = slf.renderAttrs(token);
-    return result.replace(/^<pre([ >])/, (_, ch) => `<pre${attrsStr}${ch}`);
-  };
+      if (!savedAttrs || savedAttrs.length === 0) {
+        return result;
+      }
+
+      // Inject user attrs into the opening <pre> tag.
+      const attrsStr = slf.renderAttrs(token);
+      return result.replace(/^<pre([ >])/, (_, ch) => `<pre${attrsStr}${ch}`);
+    };
+  }
 };
 
 /**

--- a/test.js
+++ b/test.js
@@ -73,6 +73,28 @@ describe('markdown-it-attrs fence renderer', () => {
     const res = md.render(src);
     assert.equal(res, '<pre><code class="language-js">foo();\n</code></pre>\n');
   });
+
+  it('should not override an existing custom fence renderer', () => {
+    const md = Md();
+    const customFence = (tokens, idx) => {
+      const token = tokens[idx];
+      return '<pre class="custom"><code>' + md.utils.escapeHtml(token.content) + '</code></pre>\n';
+    };
+    md.renderer.rules.fence = customFence;
+    md.use(attrs);
+
+    const src = '```js {data-file="index.js"}\nfoo();\n```';
+    const res = md.render(src);
+    assert.equal(md.renderer.rules.fence, customFence);
+    assert.equal(res, '<pre class="custom"><code>foo();\n</code></pre>\n');
+  });
+
+  it('should allow opting out of pre attrs renderer', () => {
+    const md = Md().use(attrs, { fenceAttrsOnPre: false });
+    const src = '```js {data-file="index.js"}\nfoo();\n```';
+    const res = md.render(src);
+    assert.equal(res, '<pre><code data-file="index.js" class="language-js">foo();\n</code></pre>\n');
+  });
 });
 
 function describeTestsWithOptions(options, postText) {

--- a/test.js
+++ b/test.js
@@ -59,6 +59,22 @@ describe('markdown-it-attrs', () => {
   });
 });
 
+describe('markdown-it-attrs fence renderer', () => {
+  it('should add attributes to <pre> on fenced code blocks', () => {
+    const md = Md().use(attrs);
+    const src = '```js {data-file="index.js"}\nfoo();\n```';
+    const res = md.render(src);
+    assert.equal(res, '<pre data-file="index.js"><code class="language-js">foo();\n</code></pre>\n');
+  });
+
+  it('should keep language class on <code> with no attrs', () => {
+    const md = Md().use(attrs);
+    const src = '```js\nfoo();\n```';
+    const res = md.render(src);
+    assert.equal(res, '<pre><code class="language-js">foo();\n</code></pre>\n');
+  });
+});
+
 function describeTestsWithOptions(options, postText) {
   describe('markdown-it-attrs.utils' + postText, () => {
     it(replaceDelimiters('should parse {.class ..css-module #id key=val .class.with.dot}', options), () => {
@@ -315,13 +331,13 @@ function describeTestsWithOptions(options, postText) {
 
     it(replaceDelimiters('should support code blocks', options), () => {
       src = '```{.c a=1 #ii}\nfor i in range(10):\n```';
-      expected = '<pre><code class="c" a="1" id="ii">for i in range(10):\n</code></pre>\n';
+      expected = '<pre class="c" a="1" id="ii"><code>for i in range(10):\n</code></pre>\n';
       assert.equal(md.render(replaceDelimiters(src, options)), expected);
     });
 
     it(replaceDelimiters('should support code blocks with language defined', options), () => {
       src = '```python {.c a=1 #ii}\nfor i in range(10):\n```';
-      expected = '<pre><code class="c language-python" a="1" id="ii">for i in range(10):\n</code></pre>\n';
+      expected = '<pre class="c" a="1" id="ii"><code class="language-python">for i in range(10):\n</code></pre>\n';
       assert.equal(md.render(replaceDelimiters(src, options)), expected);
     });
 


### PR DESCRIPTION
## Summary
- installs the plugin fence wrapper only when markdown-it is still using its default `fence` renderer
- keeps user-defined/custom `fence` renderers untouched
- adds new option `fenceAttrsOnPre` (default `true`) so users can opt out of pre-level attribute placement
- keeps existing behavior for fenced code language classes and non-fence features

## Why
- resolves the fenced-code attribute placement need without breaking projects that already provide custom fence rendering
- gives users explicit control to disable the plugin fence wrapper

## Tests
- adds regression coverage for preserving existing custom fence renderers
- adds coverage for `fenceAttrsOnPre: false` opt-out

## Validation
- `npm test`