### PR TITLE
feat: add errorHandler option to handle pattern transform errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Add classes, identifiers and attributes to your markdown with `{.class #identifi
 - [Support](#support)
 - [Usage](#usage)
 - [Security](#security)
+- [Error handling](#error-handling)
 - [Limitations](#limitations)
 - [Ambiguity](#ambiguity)
 - [Custom rendering](#custom-rendering)
@@ -135,6 +136,22 @@ Output:
 ```html
 <p id="red" class="green" regex="allowed">text</p>
 ```
+
+## Error handling
+
+By default, if a pattern transform throws an error, the error is logged with `console.error`
+and rendering continues with a best-effort result. Pass `errorHandler` to change this behavior:
+
+```js
+md.use(markdownItAttrs, {
+  errorHandler: (error, patternName) => {
+    throw error;
+  }
+});
+```
+
+If it throws the error like above, the error propagates out of `md.render()` / `md.renderInline()`,
+otherwise rendering continues as normal.
 
 ## Limitations
 markdown-it-attrs relies on markdown parsing in markdown-it, which means some

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,7 @@ declare namespace markdownItAttrs {
     allowedAttributes?: AllowedAttribute[];
     allowedAttributeValues?: AllowedAttribute[];
     fenceAttrsOnPre?: boolean;
+    errorHandler?: (error: Error, patternName: string) => void;
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const patternsConfig = require('./patterns.js');
  * @property {AllowedAttribute[]} allowedAttributes empty means no limit
  * @property {AllowedAttribute[]} allowedAttributeValues empty means no limit
  * @property {boolean} fenceAttrsOnPre set fenced-code attrs on <pre>, default true
+ * @property {(error: Error, patternName: string) => void} errorHandler called when a pattern transform throws; default logs via console.error
  *
  * @typedef {string|RegExp} AllowedAttribute rule of allowed attribute
  *
@@ -96,9 +97,13 @@ module.exports = function attributes(md, options_) {
               p--;
             }
           } catch (error) {
-            // eslint-disable-next-line no-console
-            console.error(`markdown-it-attrs: Error in pattern '${pattern.name}': ${error.message}`);
-            console.error(error.stack);
+            if (typeof options.errorHandler === 'function') {
+              options.errorHandler(error, pattern.name);
+            } else {
+              // eslint-disable-next-line no-console
+              console.error(`markdown-it-attrs: Error in pattern '${pattern.name}': ${error.message}`);
+              console.error(error.stack);
+            }
           }
         }
       }

--- a/test.js
+++ b/test.js
@@ -97,6 +97,43 @@ describe('markdown-it-attrs fence renderer', () => {
   });
 });
 
+describe('markdown-it-attrs errorHandler', () => {
+  // input that makes a pattern transform throw
+  const failingSrc = '[test](test\r.com){.download download}';
+
+  it('should call errorHandler instead of logging when a transform throws', () => {
+    let called = null;
+    const md = Md().use(attrs, {
+      errorHandler: (error, patternName) => { called = { error, patternName }; }
+    });
+    md.renderInline(failingSrc);
+    assert.ok(called, 'errorHandler should have been called');
+    assert.ok(called.error instanceof Error);
+    assert.equal(typeof called.patternName, 'string');
+  });
+
+  it('should propagate the error when errorHandler throws', () => {
+    const md = Md().use(attrs, {
+      errorHandler: (error) => { throw error; }
+    });
+    assert.throws(() => md.renderInline(failingSrc), Error);
+  });
+
+  it('should not throw and fall back to console.error without errorHandler', () => {
+    const md = Md().use(attrs);
+    const original = console.error;
+    const logged = [];
+    console.error = (...args) => { logged.push(args.join(' ')); };
+    try {
+      assert.doesNotThrow(() => md.renderInline(failingSrc));
+    } finally {
+      console.error = original;
+    }
+    assert.ok(logged.length > 0, 'should log to console.error');
+    assert.ok(logged.some(msg => msg.includes('markdown-it-attrs')), 'should mention markdown-it-attrs');
+  });
+});
+
 function describeTestsWithOptions(options, postText) {
   describe('markdown-it-attrs.utils' + postText, () => {
     it(replaceDelimiters('should parse {.class ..css-module #id key=val .class.with.dot}', options), () => {


### PR DESCRIPTION
This PR adds an `errorHandler` option that can be passed to change how errors are handled.

We've been using `markdown-it-attrs` for a long time (thank you for creating it!) and were still on `markdown-it` 12.2.3 and `markdown-it-attrs` 4.1.3 as of yesterday. When I upgraded to the latest version, I noticed that render errors are now swallowed and reported with a `console.error`. I want to be able to catch the error myself, which is why I made this change.

Without this option, I'm stuck with an ugly hack that intercepts `console.error`, detects the `markdown-it-attrs:` message, and re-throws. Roughly:

```js

function renderMarkdown(value, isInline) {
    const consoleError = console.error;
    let attrsError = null;
    console.error = (...args) => {
      if (typeof args[0] === 'string' && args[0].startsWith('markdown-it-attrs:')) {
        attrsError = args[0];
        return;
      }
      consoleError.apply(console, args);
    };
    try {
      const rendered = isInline ? md.renderInline(value) : md.render(value);
      if (attrsError) throw new Error(attrsError);

      return rendered;
    } finally {
      console.error = consoleError;
    }
}
```

This is brittle since it's coupled to a private log string. An `errorHandler` option gives a stable way to observe or re-throw the error instead, so I'd really appreciate it if you'd consider adding it. I've also added tests covering the new option.
